### PR TITLE
Align treesitter `get_node_text` to new api

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,60 @@
+# Development
+
+## Extending/Adding selector
+
+The [internal treesitter plugin](./lua/tscf/init.lua) will return data about the current buffer file in format of a table.
+There are two functions that can be called, one of them is probably only needed (formatted one).
+
+So how it works is: `User > Command > Selector (Fuzzy Finder) > Treesitter part`
+
+The `Selector` can be exchanged by adding more edgecases to the `Command` (see [main file in plugin folder](./plugin/tscf.vim)).
+
+The `Selector` internally calls the treesitter part, which is either
+* `:lua require("tscf").get_current_functions()` or
+* `:lua require("tscf").get_current_functions_formatted()`
+both return the same information, but the formatted function already has the tables concatted into a table of strings.
+
+Examples can be found for vimscript and lua in the following parts:
+* [FZF (vimscript - autoload/tscf/selector)](./autoload/tscf/selector/fzf.vim)
+* [Telescope (lua - lua/tscf/selector)](./lua/tscf/selector/telescope.lua)
+
+In general the functions can be called like following, and return:
+* vimscript: `luaeval('require("tscf").get_current_functions()')`
+  * `[[ "line_number": 1, "function_name": "name" ], ...]`
+* lua: `require("tscf").get_current_functions()`
+  * `{{ "line_number": 1, "function_name": "name" }, ...}`
+* formatted call (`get_current_functions_formatted`)
+  * same call as in vimscript and lua examples
+  * `["line_number:\t function_name", "123:\t foo"]` or `{"line_number:\t function_name", "123:\t foo"}`
+
+
+## LSP
+
+The lua code uses [EmmyLua Annotations](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations)
+from the [sumneko lua lsp](https://github.com/sumneko/lua-language-server)
+to enable hover docs and generally improve the development environment/workflow.
+
+
+## Vim Help
+
+* Add data to the help file (in doc)
+* Run `:helptag doc/` to regenerate tags
+
+
+## Debugging
+
+For better debugging, uncomment the `package.loaded` part and comment out the `finish` in the plugin folder
+
+Afterwards resourcing the files or init.vim (with the plug install) will make it easy to develop
+
+Example:
+* in init.vim: the plugin is installed via direct path
+* then run `:so ~/.config/nvim/init.vim | GetCurrentFunctions`
+
+
+## Inspection of treesitter
+
+Starting with neovim version 0.9 the `treesitter playground` is integrated into treesitter and can be opened via `:InspectTree`.
+
+This will show what node is under the cursor and the general structure, and can help with implementing new ways of declaring functions,
+or to update the handling of functions for other languages.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # treesitter-current-functions
 
-(also `tscf`) is a neovim plugin that builds on top of treesitter to
+treesitter-current-functions (also `tscf`) is a neovim plugin that builds on top of treesitter to
 
 * show all functions or function-like structures in the current buffer
 * open a selection tool (`fzf`, `telescope`, etc.)
@@ -19,15 +19,15 @@ to quickly jump to the wanted function location
 
 ## Disclaimer
 
-The plugin is by far not done and not tested, I am just starting with lua, vimscript and treesitter, which is why it will break,
-not work as expected or show wrong results.
+The repo is my first try at a plugin for `vim`/`lua`/`treesitter`.
+It can happen that a call will jump to an incorrect location or that it can not find all possible functions,
+but as it will only jump, nothing too critical (like deleting text) should be happening even in the worst case.
 
-Not all languages are tested (by far) and not all ways of declaring functions are implemented.
-I mainly added ways that I most likely will face.
+Not all languages are tested (by far) and not all ways of declaring functions are implemented, but it might still work with not tested languages, if the treesitter structure is similar to others.
 
-Fuzzy finders might break, depending on which ones (I mainly use `FZF` so `Telescope` might break from time to time).
+Fuzzy finders might break, depending on which ones are used and tested (I will most likely only test one that I am using at the time).
 
-The plugin should not be able to do destructive work, the only things that can happen is, that it shows wrong information or jump to wrong places.
+The plugin was tested with neovim version 0.8.3 and up, but can possibly work with earlier versions as well (depends on the given neovim treesitter apis, which are still experimental and change a lot).
 
 
 ## Install & Setup
@@ -38,6 +38,14 @@ The plugin should not be able to do destructive work, the only things that can h
 * Install one Selection tool
   * [fzf](https://github.com/junegunn/fzf.vim)
   * [telescope](https://github.com/nvim-telescope/telescope.nvim)
+
+An example (via [lazy](https://github.com/folke/lazy.nvim)) could look something like:
+```lua
+{
+  "eckon/treesitter-current-functions",
+  dependencies = { "nvim-treesitter/nvim-treesitter", "nvim-telescope/telescope.nvim" },
+},
+```
 
 Quickly call the plugin, without any mappings:
 ```vim
@@ -58,56 +66,4 @@ For more information see
 * `:help tscf-installation`
 * `:help tscf-usage`
 
-
-# Development
-
-## Extending/Adding selector
-
-The [internal treesitter plugin](./lua/tscf/init.lua) will return data about the current buffer file in format of a table.
-There are two functions that can be called, one of them is probably only needed (formatted one).
-
-So how it works is: `User > Command > Selector (Fuzzy Finder) > Treesitter part`
-
-The `Selector` can be exchanged by adding more edgecases to the `Command` (see [main file in plugin folder](./plugin/tscf.vim)).
-
-The `Selector` internally calls the treesitter part, which is either
-* `:lua require("tscf").get_current_functions()` or
-* `:lua require("tscf").get_current_functions_formatted()`
-both return the same information, but the formatted function already has the tables concatted into a table of strings.
-
-Examples can be found for vimscript and lua in the following parts:
-* [FZF (vimscript - autoload/tscf/selector)](./autoload/tscf/selector/fzf.vim)
-* [Telescope (lua - lua/tscf/selector)](./lua/tscf/selector/telescope.lua)
-
-In general the functions can be called like following, and return:
-* vimscript: `luaeval('require("tscf").get_current_functions()')`
-  * `[[ "line_number": 1, "function_name": "name" ], ...]`
-* lua: `require("tscf").get_current_functions()`
-  * `{{ "line_number": 1, "function_name": "name" }, ...}`
-* formatted call (`get_current_functions_formatted`)
-  * same call as in vimscript and lua examples
-  * `["line_number:\t function_name", "123:\t foo"]` or `{"line_number:\t function_name", "123:\t foo"}`
-
-
-## LSP
-
-The lua code uses [EmmyLua Annotations](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations)
-from the [sumneko lua lsp](https://github.com/sumneko/lua-language-server)
-to enable hover docs and generally improve the development environment/workflow.
-
-
-## Vim Help
-
-* Add data to the help file (in doc)
-* Run `:helptag doc/` to regenerate tags
-
-
-## Debugging
-
-For better debugging, uncomment the `package.loaded` part and comment out the `finish` in the plugin folder
-
-Afterwards resourcing the files or init.vim (with the plug install) will make it easy to develop
-
-Example:
-* in init.vim: the plugin is installed via direct path
-* then run `:so ~/.config/nvim/init.vim | GetCurrentFunctions`
+Some information about development of the plugin can be found [here](./DEVELOPMENT.md).

--- a/lua/tscf/init.lua
+++ b/lua/tscf/init.lua
@@ -43,10 +43,10 @@ local function get_node_information(node)
     return nil
   end
 
-  local function_name = vim.treesitter.query.get_node_text(function_name_node, 0)
+  local function_name = vim.treesitter.get_node_text(function_name_node, 0)
 
   -- as fallback in case named node does not exist
-  local line_content = vim.treesitter.query.get_node_text(node, 0)
+  local line_content = vim.treesitter.get_node_text(node, 0)
 
   -- return line content in case we have no name (happens if there is no named node)
   function_name = function_name or line_content
@@ -127,7 +127,7 @@ local function get_function_list_of_parent(parent)
 
     if is_complex_recursive_structure then
       local structure_name_node = get_named_node(tsnode, "name")
-      local structure_name = vim.treesitter.query.get_node_text(structure_name_node, 0)
+      local structure_name = vim.treesitter.get_node_text(structure_name_node, 0)
 
       -- body this might contain functions (methods)
       local body = get_named_node(tsnode, "body")


### PR DESCRIPTION
The previous call to `get_node_text` was deprecated, see following message:

> vim.treesitter.query.get_node_text() is deprecated, use vim.treesitter.get_node_text() instead. :help deprecated
> This feature will be removed in Nvim version 0.10

This can be seen in the 0.9 deprecation news:
https://github.com/neovim/neovim/blob/master/runtime/doc/news-0.9.txt#L317

To be save I also tried this fix with the latest neovim 0.8.3 version, and it seems to be working.

Closes #5