### PR TITLE
Add identifier of declaration for `c`

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,2 @@
+indent_type = "Spaces"
+indent_width = 2

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: lua
+
+format:
+	npx @johnnymorganz/stylua-bin \
+		--config-path ./.stylua.toml \
+		--glob '*.lua' \
+		./lua

--- a/lua/tscf/selector/telescope.lua
+++ b/lua/tscf/selector/telescope.lua
@@ -1,8 +1,8 @@
-local finders = require "telescope.finders"
-local pickers = require "telescope.pickers"
-local config = require "telescope.config"
-local actions = require "telescope.actions"
-local state = require "telescope.actions.state"
+local finders = require("telescope.finders")
+local pickers = require("telescope.pickers")
+local config = require("telescope.config")
+local actions = require("telescope.actions")
+local state = require("telescope.actions.state")
 
 local M = {}
 
@@ -29,7 +29,6 @@ local function jump_to_selected_line(prompt_bufnr)
   vim.cmd("normal! zz_")
 end
 
-
 M.init = function()
   local output = require("tscf").get_current_functions_formatted()
 
@@ -44,18 +43,20 @@ M.init = function()
     return
   end
 
-  pickers.new({}, {
-    prompt_title = "Functions",
-    finder = finders.new_table({
-      results = output,
-    }),
-    sorter = config.values.generic_sorter({}),
-    attach_mappings = function(_, map)
-      map("i", "<CR>", jump_to_selected_line)
-      map("n", "<CR>", jump_to_selected_line)
-      return true
-    end
-  }):find()
+  pickers
+    .new({}, {
+      prompt_title = "Functions",
+      finder = finders.new_table({
+        results = output,
+      }),
+      sorter = config.values.generic_sorter({}),
+      attach_mappings = function(_, map)
+        map("i", "<CR>", jump_to_selected_line)
+        map("n", "<CR>", jump_to_selected_line)
+        return true
+      end,
+    })
+    :find()
 end
 
 return M

--- a/scripts/examples/example.c
+++ b/scripts/examples/example.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+struct student
+{
+   char name[50];
+   int height;
+};
+
+int main(){
+}
+
+bool8 sub_8039880(void)
+{
+  return (CountMailType(WONDER_MAIL_TYPE_SOS) != 0 || CountMailType(WONDER_MAIL_TYPE_OKD) != 0 || sub_8011C1C() == 2);
+}

--- a/scripts/examples/example.c.expected
+++ b/scripts/examples/example.c.expected
@@ -1,0 +1,7 @@
+{ {
+    function_name = "main",
+    line_number = 8
+  }, {
+    function_name = "sub_8039880",
+    line_number = 11
+  } }


### PR DESCRIPTION
As mentioned in #9, currently `c` does not show any functions. This adds these kinds of declarations, which hopefully also adds other languages.

Also adds some general formatting/linting to the repo and applies this on all lua files.

Closes #9 