### PR TITLE
Cpp extension

### DIFF
--- a/lua/tscf/init.lua
+++ b/lua/tscf/init.lua
@@ -24,6 +24,15 @@ local function get_named_node(parent, named)
       return node
     end
 
+    -- Edge case for c++ reference return types
+    if node:type() == "reference_declarator" then
+      for child, _ in node:iter_children() do
+        if child:type() == "function_declarator" then
+          return get_named_node(child, "identifier")
+        end
+      end
+    end
+
     -- some languages have deeply nested structures
     -- in "declarator" parts can exist as well
     if name == "declarator" then

--- a/lua/tscf/init.lua
+++ b/lua/tscf/init.lua
@@ -33,8 +33,15 @@ local function get_named_node(parent, named)
       return node
     end
 
+    local is_cpp = is_file_type('cpp')
+
+    -- Edge case for c++ operator overloads
+    if node:type() == "operator_name" and is_cpp then
+      return node
+    end
+
     -- Edge case for c++ reference return types
-    if node:type() == "reference_declarator" then
+    if node:type() == "reference_declarator" and is_cpp then
       for child, _ in node:iter_children() do
         if child:type() == "function_declarator" then
           return get_named_node(child, "identifier")

--- a/scripts/examples/example.cpp
+++ b/scripts/examples/example.cpp
@@ -1,28 +1,33 @@
-#include "app.h"
+#include <utility>
 
-#include <chrono>
-#include <thread>
+/*
+ * Test 1: Basics, method definitions both inside and outside the class definition. Also testing basic
+ *          functions with primitive, pointer, and reference return types.
+ */
 
-#include "../data/api.h"
+class test_1_out {
 
-#define COLOR_HIGHLIGHT 1
-#define COLOR_MODAL_BORDER 2
+private:
+    int a, b;
 
-App *App::instance = 0;
+public:
+    std::pair<int, int> get_ab() const;
+    test_1_out(int _a, int _b);
+    ~test_1_out();
+};
+test_1_out *test_1_out_inst = nullptr;
 
-App *App::getInstance() {
-  if (instance == 0) {
-    instance = new App();
-  }
-  return instance;
+test_1_out::test_1_out(int _a, int _b)   { a = _a; b = _b; }
+test_1_out::~test_1_out()                {  }
+std::pair<int, int> test_1_out::get_ab() const { return { a, b }; }
+
+test_1_out get_test_1_out_inst_reg() {
+    return *test_1_out_inst;
+}
+test_1_out *get_test_1_out_inst_ptr() {
+    return test_1_out_inst;
+}
+test_1_out &get_test_1_out_inst_ref() {
+   return *test_1_out_inst;
 }
 
-App::~App() { endwin(); }
-
-App::App() {}
-
-int App::getKeyPress() {}
-
-void App::pushKey(int key) {}
-
-void App::drawMainWinList() {}

--- a/scripts/examples/example.cpp
+++ b/scripts/examples/example.cpp
@@ -34,7 +34,7 @@ test_1_out &get_test_1_out_inst_ref() {
 
 
 /*
- * Test 2: Templated functions both inside and outside of class definitions.
+ * Test 2: Templated functions outside of class definitions.
  */
 
 template <typename T>
@@ -61,6 +61,25 @@ test_2_out<std::uint64_t> *get_test_2_out_inst_ptr() {
 test_2_out<std::uint64_t> &get_test_2_out_inst_ref() {
     return *test_2_out_inst;
 }
+
+
+/*
+ * Test 3: Operator overloading.
+ */
+
+struct test_3_out {
+    std::uint64_t x, y, z;
+};
+
+test_3_out operator+(const test_3_out &a, const test_3_out &b) {
+    return { a.x + b.x, a.y + b.y, a.z + b.z };
+}
+
+test_3_out operator-(const test_3_out &a, const test_3_out &b) {
+    return { a.x - b.x, a.y - b.y, a.z - b.z };
+}
+
+
 
 /* TODO: Functions declared inside a class as follows still don't appear
 

--- a/scripts/examples/example.cpp
+++ b/scripts/examples/example.cpp
@@ -1,7 +1,8 @@
+#include <cstdint>
 #include <utility>
 
 /*
- * Test 1: Basics, method definitions both inside and outside the class definition. Also testing basic
+ * Test 1: Basics, method definitions outside the class definition. Also testing basic
  *          functions with primitive, pointer, and reference return types.
  */
 
@@ -30,4 +31,42 @@ test_1_out *get_test_1_out_inst_ptr() {
 test_1_out &get_test_1_out_inst_ref() {
    return *test_1_out_inst;
 }
+
+
+/*
+ * Test 2: Templated functions both inside and outside of class definitions.
+ */
+
+template <typename T>
+class test_2_out {
+
+private:
+    T a, b;
+
+public:
+    std::pair<T, T> get_ab() const;
+    test_2_out(T _a, T _b);
+};
+test_2_out<std::uint64_t> *test_2_out_inst = nullptr;
+
+template <typename T> test_2_out<T>::test_2_out(T _a, T _b) { a = _a; b = _b; }
+template <typename T> std::pair<T, T> test_2_out<T>::get_ab() const { return { a, b }; }
+
+test_2_out<std::uint64_t> get_test_2_out_inst_reg() {
+    return *test_2_out_inst;
+}
+test_2_out<std::uint64_t> *get_test_2_out_inst_ptr() {
+    return test_2_out_inst;
+}
+test_2_out<std::uint64_t> &get_test_2_out_inst_ref() {
+    return *test_2_out_inst;
+}
+
+/* TODO: Functions declared inside a class as follows still don't appear
+
+   class a {
+       void foo() { ... }
+   };
+
+*/
 

--- a/scripts/examples/example.cpp.expected
+++ b/scripts/examples/example.cpp.expected
@@ -1,19 +1,34 @@
 { {
-    function_name = "test_1_out",
-    line_number = 20
-  }, {
-    function_name = "~test_1_out",
+    function_name = "test_1_out::test_1_out",
     line_number = 21
   }, {
-    function_name = "get_ab",
+    function_name = "test_1_out::~test_1_out",
     line_number = 22
   }, {
+    function_name = "test_1_out::get_ab",
+    line_number = 23
+  }, {
     function_name = "get_test_1_out_inst_reg",
-    line_number = 24
+    line_number = 25
   }, {
     function_name = "get_test_1_out_inst_ptr",
-    line_number = 27
+    line_number = 28
   }, {
     function_name = "get_test_1_out_inst_ref",
-    line_number = 30
+    line_number = 31
+  }, {
+    function_name = "test_2_out<T>::test_2_out",
+    line_number = 52
+  }, {
+    function_name = "test_2_out<T>::get_ab",
+    line_number = 53
+  }, {
+    function_name = "get_test_2_out_inst_reg",
+    line_number = 55
+  }, {
+    function_name = "get_test_2_out_inst_ptr",
+    line_number = 58
+  }, {
+    function_name = "get_test_2_out_inst_ref",
+    line_number = 61
   } }

--- a/scripts/examples/example.cpp.expected
+++ b/scripts/examples/example.cpp.expected
@@ -31,4 +31,10 @@
   }, {
     function_name = "get_test_2_out_inst_ref",
     line_number = 61
+  }, {
+    function_name = "operator+",
+    line_number = 74
+  }, {
+    function_name = "operator-",
+    line_number = 78
   } }

--- a/scripts/examples/example.cpp.expected
+++ b/scripts/examples/example.cpp.expected
@@ -1,19 +1,19 @@
 { {
-    function_name = "getInstance",
-    line_number = 13
-  }, {
-    function_name = "~App",
+    function_name = "test_1_out",
     line_number = 20
   }, {
-    function_name = "App",
+    function_name = "~test_1_out",
+    line_number = 21
+  }, {
+    function_name = "get_ab",
     line_number = 22
   }, {
-    function_name = "getKeyPress",
+    function_name = "get_test_1_out_inst_reg",
     line_number = 24
   }, {
-    function_name = "pushKey",
-    line_number = 26
+    function_name = "get_test_1_out_inst_ptr",
+    line_number = 27
   }, {
-    function_name = "drawMainWinList",
-    line_number = 28
+    function_name = "get_test_1_out_inst_ref",
+    line_number = 30
   } }


### PR DESCRIPTION
In these four commits, four things have been changed:

1) Functions with reference return types did not previously appear. They do now, example:

![image](https://github.com/eckon/treesitter-current-functions/assets/96510931/212b32fe-aa63-4633-adcb-b3e5731700f0)

2) Operator overloads did not previously appear. They do now, example:

![image](https://github.com/eckon/treesitter-current-functions/assets/96510931/1ab3e5a6-cef8-4395-aff9-fc44a03b8b85)

3) Templated functions did not previously appear. They do now, example:

![image](https://github.com/eckon/treesitter-current-functions/assets/96510931/af473498-b596-4d2c-8af6-ea5791560490)

4) `get_node_information` will now know when a C++ file is in the current buffer and attempt to add the class or struct name to the front of what was previously displayed. The reason for this is because if two methods from two different classes or structs have the same name, this makes it easier to differentiate between the two. You can see below that this information isn't added if the function isn't a class or struct method:

![image](https://github.com/eckon/treesitter-current-functions/assets/96510931/df6f9fce-659d-4cc5-8b80-b9f9944a2521)

I just feel like this is a lot easier to navigate as opposed to all three functions all being displayed as simply "test".


I also completely redid the `example.cpp` and tried to make it easy to tell exactly what was being tested where. I also tried to make sure that what I have left in it's place tests all the same things that the old `example.cpp` did, in addition to testing the additional stuff I've mentioned above.

Finally, the tests I've added in the new example.cpp all pass, and tests for all other languages still pass as well. Thanks for reading this over! Feel free to point out anything that looks off or if something could be done better (I do not write lua often).