### PR TITLE
Cpp and rust fixes

### DIFF
--- a/lua/tscf/init.lua
+++ b/lua/tscf/init.lua
@@ -191,6 +191,7 @@ local function get_function_list_of_parent(parent)
     -- structure that most likely have multiple functions internally
     local is_complex_recursive_structure = tsnode:type() == "class_declaration"
       or tsnode:type() == "namespace_declaration"
+      or tsnode:type() == "namespace_definition"
 
     if is_complex_recursive_structure then
       local structure_name_node = get_named_node(tsnode, "name")
@@ -204,10 +205,15 @@ local function get_function_list_of_parent(parent)
       local body = get_named_node(tsnode, "body")
       local info = get_function_list_of_parent(body)
 
+      local separator = " > "
+      if tsnode:type() == "namespace_definition" then
+        separator = "::"
+      end
+
       for _, node_information in ipairs(info) do
         -- append structure name infront of methods (or other structures)
         if structure_name ~= nil then
-          node_information.function_name = structure_name .. " > " .. node_information.function_name
+          node_information.function_name = structure_name .. separator .. node_information.function_name
         end
 
         table.insert(content, node_information)

--- a/lua/tscf/init.lua
+++ b/lua/tscf/init.lua
@@ -143,6 +143,7 @@ local function get_function_list_of_parent(parent)
       or tsnode:type() == "method_definition"
       or tsnode:type() == "method_declaration"
       or tsnode:type() == "constructor_declaration"
+      or tsnode:type() == "function_item"
 
     if is_simple_function then
       local info = get_node_information(tsnode)
@@ -192,9 +193,13 @@ local function get_function_list_of_parent(parent)
     local is_complex_recursive_structure = tsnode:type() == "class_declaration"
       or tsnode:type() == "namespace_declaration"
       or tsnode:type() == "namespace_definition"
+      or tsnode:type() == "impl_item"
 
     if is_complex_recursive_structure then
       local structure_name_node = get_named_node(tsnode, "name")
+      if structure_name_node == nil then
+        structure_name_node = get_typed_node(tsnode, "type_identifier")
+      end
 
       local structure_name = nil
       if structure_name_node ~= nil then
@@ -206,7 +211,7 @@ local function get_function_list_of_parent(parent)
       local info = get_function_list_of_parent(body)
 
       local separator = " > "
-      if tsnode:type() == "namespace_definition" then
+      if tsnode:type() == "namespace_definition" or tsnode:type() == "impl_item" then
         separator = "::"
       end
 

--- a/scripts/examples/example.cpp
+++ b/scripts/examples/example.cpp
@@ -80,6 +80,28 @@ test_3_out operator-(const test_3_out &a, const test_3_out &b) {
 }
 
 
+/*
+ * Test 4: Namespaces
+ */
+
+namespace test_4 {
+
+    struct test_4a {
+        void foo();
+    };
+
+    struct test_4b {
+        void foo();
+    };
+    void test_4b::foo() { /* ... */ }
+
+    void foo_a() { /* ... */ }
+    void foo_b();
+}
+
+void test_4::test_4a::foo() { /* ... */ }
+void test_4::foo_b()        { /* ... */ }
+
 
 /* TODO: Functions declared inside a class as follows still don't appear
 

--- a/scripts/examples/example.cpp.expected
+++ b/scripts/examples/example.cpp.expected
@@ -37,4 +37,16 @@
   }, {
     function_name = "operator-",
     line_number = 78
+  }, {
+    function_name = "test_4::test_4b::foo",
+    line_number = 96
+  }, {
+    function_name = "test_4::foo_a",
+    line_number = 98
+  }, {
+    function_name = "test_4::test_4a::foo",
+    line_number = 102
+  }, {
+    function_name = "test_4::foo_b",
+    line_number = 103
   } }

--- a/scripts/examples/example.rs
+++ b/scripts/examples/example.rs
@@ -1,0 +1,33 @@
+
+#[allow(dead_code)]
+struct Test1 {
+    foo: usize
+}
+impl Test1 {
+    fn new() -> Self {
+        Test1 { foo: 0 }
+    }
+}
+
+#[allow(dead_code)]
+enum Test2 {
+    Item1,
+    Item2,
+    Item3,
+}
+impl Test2 {
+    fn index(&self) -> usize {
+        match self {
+            Test2::Item1 => 0,
+            Test2::Item2 => 1,
+            Test2::Item3 => 2,
+        }
+    }
+}
+
+#[allow(unused_variables)]
+fn main() {
+    let test1 = Test1::new();
+    let test2 = Test2::Item1;
+    test2.index();
+}

--- a/scripts/examples/example.rs.expected
+++ b/scripts/examples/example.rs.expected
@@ -1,0 +1,10 @@
+{ {
+    function_name = "Test1::new",
+    line_number = 7
+  }, {
+    function_name = "Test2::index",
+    line_number = 19
+  }, {
+    function_name = "main",
+    line_number = 29
+  } }


### PR DESCRIPTION
Hello again,

In these two commits two things have changed, and both of them were relatively simple.

First, in c++, functions inside namespaces would not appear. They do now:
![Screenshot 2023-08-21 191819](https://github.com/eckon/treesitter-current-functions/assets/96510931/500c43b7-2312-415d-b58e-a83ed9ad5cdb)

Second, I don't read or write much rust but had to look over something written in rust recently and noticed that no functions appeared at all. Because I don't write much rust, I am unsure if there are additional things I should be considering, but the later commit fixes the issue for, at least, both regular functions and functions inside of `impl` bodies:
![Screenshot 2023-08-21 191746](https://github.com/eckon/treesitter-current-functions/assets/96510931/d76d9b04-85c4-4530-95aa-b7c29a16f8cb)

And of course, I've also added to the example files in `scripts/` to test these additions accordingly.

One more thing worth noting, is that I did slightly modify `get_function_list_of_parent` as well to choose `::` as a separator over ` > ` between the class name and the "recursive structure" under certain conditions. Not certain for `impl` in rust, but I can at least confirm that this is the preferred notation for namespaces in C++, so hopefully this addition isn't too much of a "language specific" thing. I am bringing this up in case it is, and it's understandable if you decide it isn't appropriate.

Thanks again for reading this over, have a nice day!