### PR TITLE
Install all ts parsers for easier adding of languages + cache parsers for a week

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,21 @@ jobs:
           tar -zxf nvim-linux64.tar.gz
           sudo ln -s $(pwd)/nvim-linux64/bin/nvim /usr/local/bin
 
-      # maybe later add some caching (see https://github.com/nvim-telescope/telescope.nvim/blob/master/.github/workflows/ci.yml)
+      - name: Create file with year and week day to cache for a week
+        run: |
+          date +%Y-%U > current-year-week
+          cat current-year-week
+
+      - name: Try getting treesitter parser cache of this week
+        id: treesitter-cache
+        uses: actions/cache@v3
+        with:
+          path: nvim-treesitter
+          key: treesitter-hash-${{ hashFiles('current-year-week') }}
+
+
       - name: Install treesitter parser
+        if: ${{ steps.treesitter-cache.outputs.cache-hit != 'true' }}
         run: |
           git clone https://github.com/nvim-treesitter/nvim-treesitter
           nvim --headless --noplugin -u scripts/minimal_init.lua +"TSInstallSync all" -c "q"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install treesitter parser
         run: |
           git clone https://github.com/nvim-treesitter/nvim-treesitter
-          nvim --headless --noplugin -u scripts/minimal_init.lua +"TSInstallSync php javascript cpp c_sharp" -c "q"
+          nvim --headless --noplugin -u scripts/minimal_init.lua +"TSInstallSync all" -c "q"
 
       - name: Run Script for tests
         run: ./scripts/run_tests.sh


### PR DESCRIPTION
This is mainly a test to see how much longer the ci will take when we download all treesitter parsers (maybe should look into some caching as well)

UPDATE: as the whole treesitter repo takes too long (around 8mins) i added caching, making the pipeline almost instant for one week (i am guessing there should not be problems with a week long cache).
mainly a week as a month seems to be too long, and this repos isnt getting enough PRs to reasonable have a cache be used multiple times a day.

depending how it ends up be, I could increase the cache time as well, but will see